### PR TITLE
Add ProductGrid component and integrate with Home page; define Produc…

### DIFF
--- a/src/app/(shop)/page.tsx
+++ b/src/app/(shop)/page.tsx
@@ -1,4 +1,7 @@
-import { Title } from "@/components";
+import { ProductGrid, Title } from "@/components";
+import { initialData } from "@/seed/seed";
+
+const products = initialData.products;
 
 export default function Home() {
   return (
@@ -8,6 +11,7 @@ export default function Home() {
         subtitle="Explore our latest products and offers"
         className="mb-2"
       />
+      <ProductGrid products={products} />
     </>
   );
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,5 @@
+export * from "./products/product-grid/ProductGrid";
+
 export * from "./ui/not-found/PageNotFound";
 export * from "./ui/title/Title";
 export * from "./ui/top-menu/TopMenu";

--- a/src/components/products/product-grid/ProductGrid.tsx
+++ b/src/components/products/product-grid/ProductGrid.tsx
@@ -1,0 +1,14 @@
+import { Product } from "@/interfaces";
+interface Props {
+  products: Product[];
+}
+
+export const ProductGrid = ({ products }: Props) => {
+  return (
+    <div className="gird grid-cols-2  sm:grid-cols-3 gap-10 mb-10">
+      {products.map((product) => (
+        <span key={product.slug}>{product.title}</span>
+      ))}
+    </div>
+  );
+};

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from "./product.interface";

--- a/src/interfaces/product.interface.ts
+++ b/src/interfaces/product.interface.ts
@@ -1,0 +1,16 @@
+export interface Product {
+  //todo: id: string;
+  description: string;
+  images: string[];
+  inStock: number;
+  price: number;
+  sizes: ValidSizes[];
+  slug: string;
+  tags: string[];
+  title: string;
+  type: ValidTypes;
+  gender: "men" | "women" | "kid" | "unisex";
+}
+
+export type ValidSizes = "XS" | "S" | "M" | "L" | "XL" | "XXL" | "XXXL";
+export type ValidTypes = "shirts" | "pants" | "hoodies" | "hats";


### PR DESCRIPTION
This pull request introduces a new `ProductGrid` component to display products on the shop's homepage and includes necessary updates to integrate it into the application. The changes involve creating the component, updating the homepage to use it, and defining a new product interface to structure product data.

### Component Addition and Integration:

* [`src/components/products/product-grid/ProductGrid.tsx`](diffhunk://#diff-45982bd9f9e6484104cf670ee5ee3ddd253abbb129c05a0d2afdaf467a02c47eR1-R14): Added the `ProductGrid` component, which accepts a list of products and displays them in a responsive grid format.
* [`src/app/(shop)/page.tsx`](diffhunk://#diff-b4b5ee09d22158a66ee3a6765ebbdae9e8bad0347b0fe99f7d3b6079e86e0deaL1-R4): Updated the homepage to import and use the `ProductGrid` component, passing the `initialData.products` as props. [[1]](diffhunk://#diff-b4b5ee09d22158a66ee3a6765ebbdae9e8bad0347b0fe99f7d3b6079e86e0deaL1-R4) [[2]](diffhunk://#diff-b4b5ee09d22158a66ee3a6765ebbdae9e8bad0347b0fe99f7d3b6079e86e0deaR14)

### Interface Definition:

* [`src/interfaces/product.interface.ts`](diffhunk://#diff-e81469e7b71092eb0adc2e221af11e141a4de64716ecee131b74644a2e79f29aR1-R16): Defined a new `Product` interface to structure product data, including fields like `title`, `price`, `sizes`, and `gender`. Also added `ValidSizes` and `ValidTypes` type definitions to specify allowed values for sizes and product types.
* [`src/interfaces/index.ts`](diffhunk://#diff-2433a58dd5b382f3ef0faf44d5ab97bf79428a0a1452d72934c9ca3c77a237bcR1): Exported the new `Product` interface for use across the application.

### Component Export:

* [`src/components/index.ts`](diffhunk://#diff-7fd43b0b162a214d655a8176a345b983bfa23ff95be8e4059e587cf9db3fc51fR1-R2): Added the `ProductGrid` component to the export list for easier imports across the codebase.…t interface