### PR TITLE
Refactor product interface and update category links for consistency

### DIFF
--- a/src/app/(shop)/category/[id]/page.tsx
+++ b/src/app/(shop)/category/[id]/page.tsx
@@ -1,23 +1,36 @@
 "use client";
-
 import { notFound } from "next/navigation";
+
+import { initialData } from "@/seed/seed";
+import { ProductGrid, Title } from "@/components";
+import { Category } from "@/interfaces";
+const seedProducts = initialData.products;
 
 interface Props {
   params: {
-    id: string;
+    id: Category;
   };
 }
 
 export default function ({ params }: Props) {
   const { id } = params;
+  const products = seedProducts.filter((product) => product.gender === id);
 
-  if (id === "kids") {
+  const labels: Record<Category, string> = {
+    men: "para Hombres",
+    women: "para Mujeres",
+    kid: "para Niños",
+    unisex: "para todos",
+  };
+
+  /*  if (id === "kid") {
     notFound();
-  }
+  } */
 
   return (
-    <div>
-      <h1>Category Page</h1>
-    </div>
+    <>
+      <Title title={`Artículos de ${labels[id]}`} className="mb-2" />
+      <ProductGrid products={products} />
+    </>
   );
 }

--- a/src/components/ui/top-menu/TopMenu.tsx
+++ b/src/components/ui/top-menu/TopMenu.tsx
@@ -35,7 +35,7 @@ export const TopMenu = () => {
         </Link>
         <Link
           className="m-2 p-2 rounded-md transition-all hover:bg-gray-100"
-          href="/category/kids"
+          href="/category/kid"
         >
           Niños
         </Link>

--- a/src/interfaces/product.interface.ts
+++ b/src/interfaces/product.interface.ts
@@ -4,13 +4,13 @@ export interface Product {
   images: string[];
   inStock: number;
   price: number;
-  sizes: ValidSizes[];
+  sizes: Size[];
   slug: string;
   tags: string[];
   title: string;
-  type: ValidTypes;
-  gender: "men" | "women" | "kid" | "unisex";
+  type: Type;
+  gender: Category;
 }
-
-export type ValidSizes = "XS" | "S" | "M" | "L" | "XL" | "XXL" | "XXXL";
-export type ValidTypes = "shirts" | "pants" | "hoodies" | "hats";
+export type Category = "men" | "women" | "kid" | "unisex";
+export type Size = "XS" | "S" | "M" | "L" | "XL" | "XXL" | "XXXL";
+export type Type = "shirts" | "pants" | "hoodies" | "hats";


### PR DESCRIPTION
This pull request introduces changes to improve type safety and enhance functionality in the category-related pages and components. The most significant updates include replacing hardcoded strings with the `Category` type, updating the `Product` interface for better type definitions, and refining the category page to dynamically display products based on the selected category.

### Type Safety Improvements:
* [`src/interfaces/product.interface.ts`](diffhunk://#diff-e81469e7b71092eb0adc2e221af11e141a4de64716ecee131b74644a2e79f29aL7-R16): Replaced hardcoded string types for `gender`, `sizes`, and `type` in the `Product` interface with dedicated type aliases (`Category`, `Size`, and `Type`) for better type safety and maintainability.

### Category Page Enhancements:
* `src/app/(shop)/category/[id]/page.tsx`: Updated the category page to dynamically filter and display products based on the selected category using `seedProducts` and a `labels` mapping. Removed the hardcoded "kids" check and replaced it with a commented-out conditional for future use. ([src/app/(shop)/category/[id]/page.tsxL2-R34](diffhunk://#diff-65684b48f22c50ce782fdfbbc2622dd5d9d6d56ddc4887766110c37f1727c022L2-R34))

### Navigation Updates:
* [`src/components/ui/top-menu/TopMenu.tsx`](diffhunk://#diff-1b7cc4f4d5a9aa1ba60ba0f7cde42888bb4b7ae0ee3a24bdba803617a193f167L38-R38): Corrected the category link for "Niños" from `/category/kids` to `/category/kid` to align with the updated `Category` type.
[Copilot is generating a summary...]